### PR TITLE
Relax Task error

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -1366,7 +1366,7 @@ fromPosix zone posix =
 [calendarexample]: https://github.com/justinmimbs/date/blob/master/examples/Calendar.elm
 
 -}
-today : Task Never Date
+today : Task x Date
 today =
     Task.map2 fromPosix Time.here Time.now
 


### PR DESCRIPTION
Using `Never` forces callers to use `Task.mapError never` to combine with Tasks that can fail in other ways. The functions in `Time` keep the error variable free for this reason.

One downside to keep in mind: the compiler calls this a major change. I'll leave it up to you when/if to merge.

Thanks for the library!