### PR TITLE
Expose daysInMonth

### DIFF
--- a/src/Date.elm
+++ b/src/Date.elm
@@ -11,6 +11,7 @@ module Date exposing
     , range
     , compare, isBetween, min, max, clamp
     , monthToNumber, numberToMonth, weekdayToNumber, numberToWeekday
+    , daysInMonth
     )
 
 {-|

--- a/src/Date.elm
+++ b/src/Date.elm
@@ -1466,7 +1466,15 @@ clamp ((RD a) as dateA) ((RD b) as dateB) ((RD x) as dateX) =
 
 -- NUMBERS OF DAYS
 
+{-| Get the number of days for the given month.
 
+    import Date exposing (fromCalendarDate, daysInMonth)
+    import Time exposing (Month(..))
+
+    daysInMonth 2020 Jan
+        == 31
+
+-}
 daysInMonth : Int -> Month -> Int
 daysInMonth y m =
     case m of


### PR DESCRIPTION
Hi,

I noticed daysInMonth was not exposed for not obvious reason, I figured I would just expose it so that I and other users of the library don't have to redefine it for their own use.

Thanks for the great library
